### PR TITLE
Feature undertow

### DIFF
--- a/Spring-server/build.gradle
+++ b/Spring-server/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:2.1.9.RELEASE")
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:2.1.9.RELEASE"
     }
 }
 
@@ -33,12 +33,15 @@ repositories {
 sourceCompatibility = 11
 targetCompatibility = 11
 
-ext['tomcat.version'] = '9.0.24'
+configurations {
+    compile.exclude module: "spring-boot-starter-tomcat"
+}
 
 dependencies {
-    compile("org.springframework.boot:spring-boot-starter-web")
+    compile "org.springframework.boot:spring-boot-starter-web"
+    compile 'org.springframework.boot:spring-boot-starter-undertow'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     // compile("org.springframework.boot:spring-boot-starter-security")
-    testCompile("org.springframework.boot:spring-boot-starter-test")
+    testCompile "org.springframework.boot:spring-boot-starter-test"
 }

--- a/Spring-server/config/application.properties
+++ b/Spring-server/config/application.properties
@@ -8,5 +8,5 @@ server.ssl.key-store = classpath:keystore/post-client.p12
 server.ssl.key-store-password = SteamFlowers
 server.ssl.key-alias = post-client
 
-# server.tomcat.remote_ip_header=x-forwarded-for
-# server.tomcat.protocol_header=x-forwarded-proto
+server.use-forward-headers=true
+server.http2.enabled = true

--- a/Spring-server/config/application.properties
+++ b/Spring-server/config/application.properties
@@ -1,5 +1,6 @@
 server.port.http = 8080
 server.port = 8443
+server.address = localhost
 
 # security.require-ssl = true 
 

--- a/Spring-server/src/main/java/hello/PostClientSecurityConfig.java
+++ b/Spring-server/src/main/java/hello/PostClientSecurityConfig.java
@@ -1,12 +1,13 @@
 package hello;
 
-import org.apache.tomcat.util.descriptor.web.SecurityCollection;
-import org.apache.tomcat.util.descriptor.web.SecurityConstraint;
+import io.undertow.UndertowOptions;
+import io.undertow.servlet.api.SecurityConstraint;
+import io.undertow.servlet.api.SecurityInfo;
+import io.undertow.servlet.api.TransportGuaranteeType;
+import io.undertow.servlet.api.WebResourceCollection;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
 import org.springframework.boot.web.servlet.server.ServletWebServerFactory;
-import org.apache.catalina.Context;
-import org.apache.catalina.connector.Connector;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,19 +15,20 @@ import org.springframework.context.annotation.Configuration;
 public class PostClientSecurityConfig {
     @Bean
     public ServletWebServerFactory servletContainer() {
-        TomcatServletWebServerFactory tomcat = new TomcatServletWebServerFactory() {
-            @Override
-            protected void postProcessContext(Context context) {
-                SecurityConstraint securityConstraint = new SecurityConstraint();
-                securityConstraint.setUserConstraint("CONFIDENTIAL");
-                SecurityCollection collection = new SecurityCollection();
-                collection.addPattern("/*");
-                securityConstraint.addCollection(collection);
-                context.addConstraint(securityConstraint);
-            }
-        };
-        tomcat.addAdditionalTomcatConnectors(redirectConnector());
-        return tomcat;
+        UndertowServletWebServerFactory undertow = new UndertowServletWebServerFactory();
+        undertow.addBuilderCustomizers(builder -> {
+            builder.addHttpListener(httpPort, "0.0.0.0");
+            builder.setServerOption(UndertowOptions.ENABLE_HTTP2, true);
+        });
+        undertow.addDeploymentInfoCustomizers(deploymentInfo -> {
+            deploymentInfo.addSecurityConstraint(new SecurityConstraint()
+                    .addWebResourceCollection(new WebResourceCollection()
+                            .addUrlPattern("/*"))
+                    .setTransportGuaranteeType(TransportGuaranteeType.CONFIDENTIAL)
+                    .setEmptyRoleSemantic(SecurityInfo.EmptyRoleSemantic.PERMIT))
+                    .setConfidentialPortManager(exchange -> httpsPort);
+        });
+        return undertow;
     }
 
     @Value("${server.port.http}")
@@ -34,14 +36,4 @@ public class PostClientSecurityConfig {
 
     @Value("${server.port}")
     int httpsPort;
-
-    private Connector redirectConnector() {
-        Connector connector = new Connector(TomcatServletWebServerFactory.DEFAULT_PROTOCOL);
-        connector.setScheme("http");
-        connector.setPort(httpPort);
-        connector.setSecure(false);
-        connector.setRedirectPort(httpsPort);
-
-        return connector;
-    }
 }

--- a/Spring-server/src/main/java/hello/PostClientSecurityConfig.java
+++ b/Spring-server/src/main/java/hello/PostClientSecurityConfig.java
@@ -17,7 +17,7 @@ public class PostClientSecurityConfig {
     public ServletWebServerFactory servletContainer() {
         UndertowServletWebServerFactory undertow = new UndertowServletWebServerFactory();
         undertow.addBuilderCustomizers(builder -> {
-            builder.addHttpListener(httpPort, "0.0.0.0");
+            builder.addHttpListener(httpPort, address);
             builder.setServerOption(UndertowOptions.ENABLE_HTTP2, true);
         });
         undertow.addDeploymentInfoCustomizers(deploymentInfo -> {
@@ -36,4 +36,7 @@ public class PostClientSecurityConfig {
 
     @Value("${server.port}")
     int httpsPort;
+
+    @Value("${server.address}")
+    String address;
 }


### PR DESCRIPTION
**Changed servlet container to undertow**

After annoying exception in terminal on every connection that is linked to tomcat an all the issues that required us to go to tomcat version 9.0.24 I changed embedded servlet container to undertow. After some testing all seems to be in order.

Also:

- changed configuration to actually use port parameters from application.properties for http redirect instead of relying on explicit constant
- added address in config to set https and http listeners redirect to same address

Side effect of this change is that without finding application.properties server now crashes hard instead of not working correctly in silence, we should make sure to embed properties in jar later, bootRun works fine for me.