### PR TITLE
Fixed gradle buildscript

### DIFF
--- a/Spring-server/build.gradle
+++ b/Spring-server/build.gradle
@@ -9,10 +9,19 @@ apply plugin: 'io.spring.dependency-management'
 sourceSets {
     main {
         resources {
-            srcDirs "src/main/resources", "../assets", "config/"
+            srcDirs "src/main/resources", "config/"
         }
     }
 }
+
+task copyWebResources{
+    copy {
+        from '../assets'
+        into 'build/resources/main/public'
+    }
+}
+
+build.dependsOn copyWebResources
 
 bootJar {
     baseName = 'post-client'


### PR DESCRIPTION
Using resource path, it was impossible to set different dropoff for resources. Instead, I remade copy task, now it copies directly to build folder, with correct path.