### PR TITLE
Probably fixed copytask not working with bootRun

### DIFF
--- a/Spring-server/build.gradle
+++ b/Spring-server/build.gradle
@@ -25,9 +25,10 @@ bootJar {
 task copyWebResources(type: Copy) {
     from '../assets'
     into 'build/resources/main/public'
+    include '**/*.html', '**/*.css' , '**/*.js', '**/*.vue'
 }
 
-build.dependsOn copyWebResources
+processResources.dependsOn copyWebResources
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
copytask now executed before processing resources
copytask now has include patterns to avoid unnecessary files being copied